### PR TITLE
fix(server): isolate production app processes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -167,7 +167,8 @@ Variable values may be TOML strings, numbers, booleans, or datetimes. Tako conve
   environment. An empty string (`release = ""`) explicitly clears the
   inherited top-level command for that env.
 - The release command runs as `sh -c "<command>"` with cwd set to the
-  new release directory and the same env an HTTP instance receives
+  new release directory, the app's per-app Unix identity on root-managed
+  production servers, and the same env an HTTP instance receives
   (merged `[vars]` + `[vars.<env>]` + secrets + `TAKO_BUILD` +
   `TAKO_DATA_DIR` + `ENV` + runtime defaults). Secrets are injected as
   env vars (release commands are one-shot; the fd 3 mechanism is
@@ -882,6 +883,8 @@ Service-manager reload/restart behavior:
 - `app/` — app-owned data exposed to the process as `TAKO_DATA_DIR`
 - `tako/` — Tako-owned per-app internal state
 
+On root-managed production servers, release directories and `data/app/` are owned by the per-app Unix user/group and are not readable by other deployed app identities by default. `data/tako/` remains owned by `tako-server` and is not exposed to app code. Spawned app and worker processes keep fd 3 bootstrap, fd 4 readiness for HTTP instances, and `127.0.0.1` loopback routing, then apply a conservative umask, `NoNewPrivileges` where supported, dropped ambient capabilities where supported, and per-app resource controls. Linux cgroup v2 is used when available to assign app processes to a per-app cgroup with default memory, CPU, and process-count limits; file-descriptor limits are applied per process.
+
 Deleting an app removes the entire `{data_dir}/apps/{app}` tree after the app is drained and stopped.
 
 During single-host upgrade orchestration, `tako-server` may enter an internal `upgrading` server mode that temporarily rejects mutating management commands (release preparation/finalization, `deploy`, `backup_now`, `restore_backup`, `scale`, `stop`, `delete`, `rollback`, `update-secrets`) until the upgrade window ends.
@@ -1198,7 +1201,7 @@ Deploy flow helpers:
 - Deploy target app path is the selected config file's parent directory relative to the source bundle root.
 - Build uses a build dir: copies project from source root into `.tako/build` (respecting `.gitignore`), symlinks `node_modules/` from the original tree (build tools read but don't modify), runs build commands in the build dir, then archives the result excluding `node_modules/`. Source and build archives preserve symlinks as symlinks; directory symlinks are not followed, and source hashes track symlink targets for cache invalidation.
 - These paths are always force-excluded from the deploy archive: `.git/`, `.tako/`, `.env*`, `node_modules/`. Additional exclusions come from `[build].exclude` and `.gitignore`.
-- Servers receive prebuilt artifacts and do not run app build steps during deploy. After extracting the artifact, `tako-server` runs the runtime plugin's production install command (e.g. `bun install --production`) before starting instances. Production install runs with the release env plus minimal process env (`PATH`, `HOME` when available); it does not inherit arbitrary `tako-server` service environment variables. When `tako-server` is root, production install runs as `tako-app`; if `tako-app` cannot be resolved, install fails instead of running as root.
+- Servers receive prebuilt artifacts and do not run app build steps during deploy. After extracting the artifact, `tako-server` runs the runtime plugin's production install command (e.g. `bun install --production`) before starting instances. Production install runs with the release env plus minimal process env (`PATH`, `HOME` when available); it does not inherit arbitrary `tako-server` service environment variables. When `tako-server` is root, each deployed app id (`{app}/{env}`) gets a deterministic Unix user and primary group (`tako-<hash>`). Production install, release commands, HTTP instances, and workflow workers for that app run as that per-app user, with the shared `tako-app` group retained only as a supplementary group for access to Tako's internal socket. If the per-app identity or shared group cannot be resolved or created, root `tako-server` fails closed instead of running app code as root.
 - Build logic runs in the build dir against the resolved stage list (precedence: `[[build_stages]]` → `[build]` → runtime default). Each stage runs `install` then `run` in declaration order.
 - Deploy uses the version pin from `runtime = "<id>@<version>"` when set. Otherwise it resolves runtime version by running `<tool> --version` directly, falling back to `latest`.
 - Artifact include precedence: in simple build mode, `build.include` -> `**/*`. In multi-stage mode, `**/*` is used (stages control output via `exclude` patterns only).
@@ -1399,7 +1402,7 @@ Apps specify routes at environment level (not per-server). Routes support:
 
 Users run a server setup script (or equivalent manual steps) to:
 
-1. Create dedicated OS users: `tako` for SSH access and running `tako-server`, plus `tako-app` for app and worker processes
+1. Create dedicated OS users/groups: `tako` for SSH access and running `tako-server`, plus the shared `tako-app` group used by app and worker processes to reach the internal socket
 2. Install `tako-server` to `/usr/local/bin/tako-server`
 3. Install and enable a host service definition for `tako-server`:
    - systemd unit on systemd hosts
@@ -1434,7 +1437,7 @@ Installer SSH key behavior:
 - Installer ensures `nc` (netcat) is available so CLI management commands can talk to `/var/run/tako/tako.sock`.
 - Installer installs the host libvips runtime used by the built-in image optimizer before starting `tako-server`.
 - Installer ensures basic networking tools are available for server operation.
-- Installer creates both `tako` and `tako-app` OS users. `tako-server` runs as `tako`; app and worker processes run as `tako-app`. If a root `tako-server` cannot resolve `tako-app`, it refuses to run production install or spawn app processes as root.
+- Installer creates the `tako` OS user and the shared `tako-app` group. `tako-server` runs as `tako`; root-managed app and worker processes run as per-app Unix users created from the deployed app id and keep `tako-app` only as a supplementary group. If a root `tako-server` cannot resolve or create the per-app identity or shared group, it refuses to run production install, release commands, HTTP instances, or workflow workers as root.
 - Installer prepares the `/opt/tako` and `/var/run/tako` roots without recursively traversing existing app releases.
 - Installer installs restricted maintenance helpers and scoped sudoers policy so the `tako` SSH user can perform non-interactive server upgrade/reload operations.
 - When the installer installs or accepts `TAKO_SSH_PUBKEY`, it also enrolls that public key for signed remote management in `/opt/tako/management-authorized-keys`.
@@ -1901,7 +1904,7 @@ The `backup` field is optional. When present, the server stores the private back
 }
 ```
 
-The server validates the app name and release version, acquires the per-app deploy lock, derives base env from release `app.json`, overlays command `vars`, injects `TAKO_BUILD`, `TAKO_DATA_DIR`, and command `secrets`, then runs `sh -c "<command_line>"` in the release directory from a cleared service environment. Parent `PATH` is inserted only when the app/release env did not already provide it. Deploy sends the freshly decrypted secrets in the `run_release` payload so first deploys and secret rotations run against the same env the new HTTP instances will receive. Success returns exit metadata; non-zero exit or timeout returns an error response with a stderr tail.
+The server validates the app name and release version, acquires the per-app deploy lock, derives base env from release `app.json`, overlays command `vars`, injects `TAKO_BUILD`, `TAKO_DATA_DIR`, and command `secrets`, then runs `sh -c "<command_line>"` in the release directory from a cleared service environment and the app's per-app Unix identity on root-managed production servers. Parent `PATH` is inserted only when the app/release env did not already provide it. Deploy sends the freshly decrypted secrets in the `run_release` payload so first deploys and secret rotations run against the same env the new HTTP instances will receive. Success returns exit metadata; non-zero exit or timeout returns an error response with a stderr tail.
 
 Server-side validation on `deploy` and app-scoped commands:
 
@@ -1971,7 +1974,7 @@ Server-side validation on `deploy` and app-scoped commands:
 
 **Instance communication model:**
 
-- App processes run as `tako-app` and do not connect to the management socket. If a root `tako-server` cannot resolve `tako-app`, spawning fails closed instead of running app code as root.
+- App and workflow worker processes run as the per-app Unix user for their deployed app id and do not connect to the management socket. The shared `tako-app` group is retained only for internal socket permissions. If a root `tako-server` cannot resolve or create the per-app identity, spawning fails closed instead of running app code as root.
 - `tako-server` controls lifecycle directly (spawn/stop/rolling update). Startup readiness is signaled by the SDK via fd 4; ongoing health is verified via active HTTP probing.
 - App processes receive `PORT=0` and `HOST=127.0.0.1`, bind to an OS-assigned loopback port, and write the actual port to fd 4. The server then routes traffic and health probes to that endpoint.
 - Secrets are passed to instances via fd 3 (file descriptor 3) at spawn time. The server creates a pipe, writes JSON-serialized secrets to the write end, and the child process reads fd 3 at startup before any user code runs. EBADF on fd 3 means the process is not running under Tako (dev mode).
@@ -2573,7 +2576,7 @@ Both work via sentinel exceptions caught by the worker. Useful for "this work is
 
 - Single shared internal socket at `{tako_data_dir}/internal.sock` (symlink → `internal-{pid}.sock`, atomically swapped during upgrades for zero-downtime handoff — same pattern as the mgmt socket). Workflow RPCs and server-side channel publishes both land here, hence the role-neutral name.
 - Every command carries an `app` field so one socket routes for every deployed app.
-- Auth: filesystem permissions only (`chmod 0660`, owned by the service user/group so `tako-app` processes can connect).
+- Auth: filesystem permissions plus app-scoped runtime tokens. The socket is `chmod 0660` and group-accessible to the shared `tako-app` group so per-app users can connect through their supplementary group.
 - SDKs read `TAKO_INTERNAL_SOCKET` and `TAKO_APP_NAME` env vars. HTTP instance and workflow worker spawners (tako-server in production and tako-dev-server in `tako dev`) share one env contract defined in `tako-core::instance_env::TakoRuntimeEnv` so the dev and prod runtimes can't drift. The SDK asserts the pair is set together at import time — a half-set env (one var without the other) is a platform bug and crashes the process on boot rather than silently failing at the first workflow enqueue or channel publish.
 - From any process: `EnqueueRun`, `Signal`, `ChannelPublish` (server-side publish goes straight to the channel store instead of round-tripping through the HTTPS proxy).
 - From worker processes: `ClaimRun`, `HeartbeatRun`, `SaveStep`, `CompleteRun`, `CancelRun`, `FailRun`, `DeferRun`, `WaitForEvent`, `RegisterSchedules`.

--- a/tako-server/src/instances/mod.rs
+++ b/tako-server/src/instances/mod.rs
@@ -674,7 +674,11 @@ impl AppManager {
         let internal_socket = tako_workflows::internal_socket_path(&data_dir);
         Self {
             apps: DashMap::new(),
-            spawner: Arc::new(Spawner::new().with_internal_socket(internal_socket)),
+            spawner: Arc::new(
+                Spawner::new()
+                    .with_data_dir(data_dir.clone())
+                    .with_internal_socket(internal_socket),
+            ),
             event_tx: tx,
             event_rx: RwLock::new(Some(rx)),
             data_dir,

--- a/tako-server/src/instances/spawner/mod.rs
+++ b/tako-server/src/instances/spawner/mod.rs
@@ -9,9 +9,7 @@ use super::{App, Instance, InstanceError, InstanceEvent, InstanceState};
 #[cfg(test)]
 use health_probe::probe_endpoint_tcp;
 use readiness::{startup_timeout_detail, wait_for_ready};
-use spawn_command::{
-    build_instance_args, build_instance_env, resolve_app_user, spawn_child_process,
-};
+use spawn_command::{build_instance_args, build_instance_env, spawn_child_process};
 use std::path::PathBuf;
 use std::sync::Arc;
 #[cfg(test)]
@@ -20,9 +18,8 @@ use tokio::time::timeout;
 
 /// Spawns and monitors app instances
 pub struct Spawner {
-    /// UID/GID of the `tako-app` user for process isolation (Unix only).
-    #[cfg(unix)]
-    app_user: Result<Option<(u32, u32)>, String>,
+    /// Server data directory used to derive app cgroup paths.
+    data_dir: PathBuf,
     /// Path to the shared Tako internal socket. When present, injected into
     /// every spawned instance as `TAKO_INTERNAL_SOCKET` so workflow `.enqueue()`
     /// and channel `.publish()` from app code work. `None` in tests.
@@ -32,10 +29,14 @@ pub struct Spawner {
 impl Spawner {
     pub fn new() -> Self {
         Self {
-            #[cfg(unix)]
-            app_user: resolve_app_user().map_err(|error| error.to_string()),
+            data_dir: PathBuf::new(),
             internal_socket: None,
         }
+    }
+
+    pub fn with_data_dir(mut self, path: PathBuf) -> Self {
+        self.data_dir = path;
+        self
     }
 
     pub fn with_internal_socket(mut self, path: PathBuf) -> Self {
@@ -61,16 +62,15 @@ impl Spawner {
         let extra_args = build_instance_args(&instance);
 
         #[cfg(unix)]
-        let app_user = app_user_for_spawn(&self.app_user, crate::unix::is_root())
-            .map_err(InstanceError::SpawnError)?;
-        #[cfg(not(unix))]
-        let app_user = None;
+        let isolation = crate::isolation::app_process_isolation(&self.data_dir, &app_name)
+            .map_err(|error| InstanceError::SpawnError(std::io::Error::other(error)))?;
 
         let (child, readiness_fd) = spawn_child_process(
             &config,
             &env,
             &extra_args,
-            app_user,
+            #[cfg(unix)]
+            isolation,
             instance.internal_token(),
             &config.secrets,
         )
@@ -172,33 +172,6 @@ impl Spawner {
             .await,
             Ok(true)
         )
-    }
-}
-
-#[cfg(unix)]
-fn app_user_for_spawn(
-    app_user: &Result<Option<(u32, u32)>, String>,
-    is_root: bool,
-) -> std::io::Result<Option<(u32, u32)>> {
-    match app_user {
-        Ok(Some(user)) => Ok(Some(*user)),
-        Ok(None) if is_root => Err(std::io::Error::other(
-            "tako-app user not found; refusing to spawn app process as root",
-        )),
-        Ok(None) => {
-            tracing::warn!("tako-app user not found; app processes will run as current user");
-            Ok(None)
-        }
-        Err(error) if is_root => Err(std::io::Error::other(format!(
-            "failed to resolve tako-app user: {error}"
-        ))),
-        Err(error) => {
-            tracing::warn!(
-                error = %error,
-                "Failed to resolve tako-app user; app processes will run as current user"
-            );
-            Ok(None)
-        }
     }
 }
 

--- a/tako-server/src/instances/spawner/spawn_command.rs
+++ b/tako-server/src/instances/spawner/spawn_command.rs
@@ -3,21 +3,9 @@ use std::collections::HashMap;
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::path::Path;
-use tokio::process::Command;
-
 #[cfg(unix)]
-pub(super) fn resolve_app_user() -> std::io::Result<Option<(u32, u32)>> {
-    match crate::unix::lookup_user_ids("tako-app")? {
-        Some((uid, gid)) => {
-            tracing::info!(uid, gid, "Resolved tako-app user for app process isolation");
-            Ok(Some((uid, gid)))
-        }
-        None => {
-            tracing::warn!("tako-app user not found");
-            Ok(None)
-        }
-    }
-}
+use tako_spawn::ProcessIsolation;
+use tokio::process::Command;
 
 pub(super) fn build_instance_env(
     config: &AppConfig,
@@ -48,6 +36,7 @@ pub(super) fn build_instance_args(instance: &Instance) -> Vec<String> {
     vec!["--instance".to_string(), instance.id.clone()]
 }
 
+#[cfg(test)]
 pub(super) fn app_child_parent_death_signal() -> Option<i32> {
     #[cfg(target_os = "linux")]
     {
@@ -113,7 +102,7 @@ fn build_child_command(
     config: &AppConfig,
     env: &HashMap<String, String>,
     extra_args: &[String],
-    app_user: Option<(u32, u32)>,
+    #[cfg(unix)] isolation: ProcessIsolation,
     secrets_fd: Option<RawFd>,
     readiness_fd: Option<RawFd>,
 ) -> std::io::Result<Command> {
@@ -121,12 +110,6 @@ fn build_child_command(
     let binary = resolve_binary_from_env(&config.command[0], env);
     let mut child_cmd = Command::new(&binary);
     child_cmd.args(&config.command[1..]).args(extra_args);
-
-    #[cfg(unix)]
-    if let Some((uid, gid)) = app_user {
-        child_cmd.uid(uid);
-        child_cmd.gid(gid);
-    }
 
     child_cmd.current_dir(&config.path).env_clear();
     for key in ["PATH", "HOME"] {
@@ -144,8 +127,6 @@ fn build_child_command(
     #[cfg(unix)]
     unsafe {
         child_cmd.pre_exec(move || {
-            install_parent_death_signal(app_child_parent_death_signal())?;
-            clear_ambient_capabilities()?;
             if let Some(fd) = secrets_fd {
                 if fd != 3 {
                     if libc::dup2(fd, 3) == -1 {
@@ -166,6 +147,7 @@ fn build_child_command(
             } else {
                 libc::close(4);
             }
+            tako_spawn::install_process_isolation(&isolation)?;
             Ok(())
         });
     }
@@ -173,60 +155,11 @@ fn build_child_command(
     Ok(child_cmd)
 }
 
-#[cfg(target_os = "linux")]
-fn clear_ambient_capabilities() -> std::io::Result<()> {
-    let result = unsafe {
-        libc::prctl(
-            libc::PR_CAP_AMBIENT,
-            libc::PR_CAP_AMBIENT_CLEAR_ALL,
-            0,
-            0,
-            0,
-        )
-    };
-    if result == -1 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-#[cfg(not(target_os = "linux"))]
-fn clear_ambient_capabilities() -> std::io::Result<()> {
-    Ok(())
-}
-
-#[cfg(target_os = "linux")]
-fn install_parent_death_signal(signal: Option<i32>) -> std::io::Result<()> {
-    let Some(signal) = signal else {
-        return Ok(());
-    };
-
-    // SAFETY: This runs in the child after fork and before exec. `prctl`,
-    // `getppid`, and `_exit` are used only with plain integer arguments.
-    let result = unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, signal) };
-    if result == -1 {
-        return Err(std::io::Error::last_os_error());
-    }
-
-    // If the parent died between fork and PR_SET_PDEATHSIG, avoid execing an
-    // immediately orphaned app process.
-    if unsafe { libc::getppid() } == 1 {
-        unsafe { libc::_exit(1) };
-    }
-
-    Ok(())
-}
-
-#[cfg(not(target_os = "linux"))]
-fn install_parent_death_signal(_signal: Option<i32>) -> std::io::Result<()> {
-    Ok(())
-}
-
 pub(super) fn spawn_child_process(
     config: &AppConfig,
     env: &HashMap<String, String>,
     extra_args: &[String],
-    app_user: Option<(u32, u32)>,
+    #[cfg(unix)] isolation: ProcessIsolation,
     token: &str,
     secrets: &HashMap<String, String>,
 ) -> std::io::Result<(tokio::process::Child, Option<OwnedFd>)> {
@@ -248,12 +181,29 @@ pub(super) fn spawn_child_process(
     #[cfg(not(unix))]
     let readiness_raw_fd = None;
 
-    let mut child_cmd =
-        build_child_command(config, env, extra_args, app_user, raw_fd, readiness_raw_fd)?;
+    #[cfg(unix)]
+    let cgroup = isolation.cgroup.clone();
+    let mut child_cmd = build_child_command(
+        config,
+        env,
+        extra_args,
+        #[cfg(unix)]
+        isolation,
+        raw_fd,
+        readiness_raw_fd,
+    )?;
     let spawn_result = child_cmd.spawn();
 
     match spawn_result {
-        Ok(child) => {
+        Ok(mut child) => {
+            #[cfg(unix)]
+            if let Some(cgroup) = cgroup
+                && let Some(pid) = child.id()
+                && let Err(error) = tako_spawn::assign_pid_to_cgroup(&cgroup, pid)
+            {
+                let _ = child.start_kill();
+                return Err(error);
+            }
             #[cfg(unix)]
             {
                 drop(readiness_write_end);

--- a/tako-server/src/instances/spawner/tests.rs
+++ b/tako-server/src/instances/spawner/tests.rs
@@ -22,39 +22,16 @@ fn test_spawner_creation() {
 
 #[test]
 #[cfg(unix)]
-fn resolve_app_user_returns_none_gracefully_for_missing_user() {
-    assert!(
-        crate::unix::lookup_user_ids("this-user-definitely-does-not-exist-tako-test")
-            .unwrap()
-            .is_none(),
-        "expected nonexistent user to return none"
-    );
-    // resolve_app_user looks up "tako-app"; on dev machines it won't exist.
-    // Calling Spawner::new() must not panic regardless.
-    let _spawner = Spawner::new();
-}
+fn app_process_isolation_uses_current_user_when_not_root() {
+    let temp = tempfile::tempdir().unwrap();
+    if crate::unix::is_root() {
+        return;
+    }
 
-#[test]
-#[cfg(unix)]
-fn app_user_for_spawn_fails_closed_for_root_lookup_error() {
-    let err = app_user_for_spawn(&Err("lookup failed".to_string()), true).unwrap_err();
-    assert_eq!(err.kind(), std::io::ErrorKind::Other);
-    assert!(err.to_string().contains("lookup failed"));
-}
-
-#[test]
-#[cfg(unix)]
-fn app_user_for_spawn_fails_closed_for_root_missing_user() {
-    let err = app_user_for_spawn(&Ok(None), true).unwrap_err();
-    assert_eq!(err.kind(), std::io::ErrorKind::Other);
-    assert!(err.to_string().contains("refusing to spawn"));
-}
-
-#[test]
-#[cfg(unix)]
-fn app_user_for_spawn_falls_back_for_non_root_lookup_error() {
-    let app_user = app_user_for_spawn(&Err("lookup failed".to_string()), false).unwrap();
-    assert_eq!(app_user, None);
+    let isolation =
+        crate::isolation::app_process_isolation(temp.path(), "demo/production").unwrap();
+    assert!(isolation.user.is_none());
+    assert!(isolation.cgroup.is_none());
 }
 
 #[test]
@@ -74,7 +51,19 @@ fn spawn_child_process_returns_permission_denied_when_app_user_switch_fails() {
         &config,
         &HashMap::new(),
         &[],
-        Some((0, 0)),
+        tako_spawn::ProcessIsolation {
+            user: Some(tako_spawn::UserIds {
+                uid: 0,
+                gid: 0,
+                supplementary_gids: Vec::new(),
+            }),
+            resource_limits: tako_spawn::ResourceLimits {
+                open_files: None,
+                processes: None,
+                address_space_bytes: None,
+            },
+            ..Default::default()
+        },
         "token",
         &HashMap::new(),
     );
@@ -106,7 +95,14 @@ async fn spawn_child_process_does_not_inherit_server_env() {
         &config,
         &HashMap::new(),
         &[],
-        None,
+        tako_spawn::ProcessIsolation {
+            resource_limits: tako_spawn::ResourceLimits {
+                open_files: None,
+                processes: None,
+                address_space_bytes: None,
+            },
+            ..Default::default()
+        },
         "token",
         &HashMap::new(),
     )

--- a/tako-server/src/isolation.rs
+++ b/tako-server/src/isolation.rs
@@ -1,0 +1,365 @@
+use std::path::Path;
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
+
+use sha2::{Digest, Sha256};
+use tako_spawn::{CgroupAssignment, ProcessIsolation, UserIds};
+
+const APP_USER_PREFIX: &str = "tako-";
+const SHARED_APP_GROUP: &str = "tako-app";
+#[cfg(target_os = "linux")]
+const CGROUP_MEMORY_MAX_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+#[cfg(target_os = "linux")]
+const CGROUP_CPU_MAX: &str = "200000 100000";
+#[cfg(target_os = "linux")]
+const CGROUP_PIDS_MAX: u64 = 512;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AppUnixIdentity {
+    pub(crate) user_name: String,
+    pub(crate) ids: UserIds,
+}
+
+pub(crate) fn app_unix_user_name(app_id: &str) -> String {
+    let digest = Sha256::digest(app_id.as_bytes());
+    let hex = hex::encode(digest);
+    format!("{APP_USER_PREFIX}{}", &hex[..16])
+}
+
+pub(crate) fn app_process_isolation(
+    data_dir: &Path,
+    app_id: &str,
+) -> Result<ProcessIsolation, String> {
+    let mut isolation = ProcessIsolation {
+        parent_death_signal: app_child_parent_death_signal(),
+        ..ProcessIsolation::default()
+    };
+
+    if !crate::unix::is_root() {
+        isolation.resource_limits = tako_spawn::ResourceLimits {
+            open_files: None,
+            processes: None,
+            address_space_bytes: None,
+        };
+        isolation.no_new_privs = false;
+        isolation.clear_ambient_capabilities = false;
+        isolation.umask = None;
+        return Ok(isolation);
+    }
+
+    let identity = ensure_app_unix_identity(app_id)?;
+    isolation.user = Some(identity.ids);
+    isolation.cgroup = prepare_app_cgroup(data_dir, app_id).ok();
+    Ok(isolation)
+}
+
+pub(crate) fn prepare_app_filesystem_isolation(
+    data_dir: &Path,
+    app_id: &str,
+    release_path: Option<&Path>,
+    data_paths: &crate::release::AppRuntimeDataPaths,
+) -> Result<Option<AppUnixIdentity>, String> {
+    prepare_app_directory_modes(data_dir, app_id, data_paths, release_path)?;
+
+    if !crate::unix::is_root() {
+        return Ok(None);
+    }
+
+    let identity = ensure_app_unix_identity(app_id)?;
+    apply_app_directory_ownership(data_dir, app_id, &identity, data_paths, release_path)?;
+    Ok(Some(identity))
+}
+
+fn prepare_app_directory_modes(
+    data_dir: &Path,
+    app_id: &str,
+    data_paths: &crate::release::AppRuntimeDataPaths,
+    release_path: Option<&Path>,
+) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let app_root = crate::release::app_root(data_dir, app_id);
+    std::fs::create_dir_all(&app_root)
+        .map_err(|e| format!("create app root {}: {e}", app_root.display()))?;
+    set_mode(&app_root, 0o750)?;
+
+    let releases_root = app_root.join("releases");
+    if releases_root.exists() {
+        set_mode(&releases_root, 0o750)?;
+    }
+    let shared_root = app_root.join("shared");
+    if shared_root.exists() {
+        set_mode(&shared_root, 0o750)?;
+    }
+    let shared_logs = shared_root.join("logs");
+    if shared_logs.exists() {
+        set_mode(&shared_logs, 0o2770)?;
+    }
+    if let Some(release_path) = release_path {
+        set_mode(release_path, 0o750)?;
+    }
+    set_mode(&data_paths.root, 0o710)?;
+    set_mode(&data_paths.app, 0o2770)?;
+    set_mode(&data_paths.tako, 0o700)?;
+
+    fn set_mode(path: &Path, mode: u32) -> Result<(), String> {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+            .map_err(|e| format!("set permissions {}: {e}", path.display()))
+    }
+
+    Ok(())
+}
+
+fn apply_app_directory_ownership(
+    data_dir: &Path,
+    app_id: &str,
+    identity: &AppUnixIdentity,
+    data_paths: &crate::release::AppRuntimeDataPaths,
+    release_path: Option<&Path>,
+) -> Result<(), String> {
+    let app_root = crate::release::app_root(data_dir, app_id);
+    crate::unix::chown_path(&app_root, 0, identity.ids.gid)
+        .map_err(|e| format!("set app root owner {}: {e}", app_root.display()))?;
+    let releases_root = app_root.join("releases");
+    if releases_root.exists() {
+        crate::unix::chown_path(&releases_root, 0, identity.ids.gid)
+            .map_err(|e| format!("set releases root owner {}: {e}", releases_root.display()))?;
+    }
+    let shared_root = app_root.join("shared");
+    if shared_root.exists() {
+        crate::unix::chown_path(&shared_root, 0, identity.ids.gid)
+            .map_err(|e| format!("set shared root owner {}: {e}", shared_root.display()))?;
+    }
+    let shared_logs = shared_root.join("logs");
+    if shared_logs.exists() {
+        chown_path_tree(&shared_logs, identity.ids.uid, identity.ids.gid)
+            .map_err(|e| format!("set shared logs owner {}: {e}", shared_logs.display()))?;
+    }
+    if let Some(release_path) = release_path {
+        chown_path_tree(release_path, identity.ids.uid, identity.ids.gid)
+            .map_err(|e| format!("set release owner {}: {e}", release_path.display()))?;
+    }
+    chown_path_tree(&data_paths.app, identity.ids.uid, identity.ids.gid)
+        .map_err(|e| format!("set app data owner {}: {e}", data_paths.app.display()))?;
+    crate::unix::chown_path(&data_paths.root, 0, identity.ids.gid)
+        .map_err(|e| format!("set app data root owner {}: {e}", data_paths.root.display()))?;
+    crate::unix::chown_path(&data_paths.tako, 0, 0)
+        .map_err(|e| format!("set internal data owner {}: {e}", data_paths.tako.display()))?;
+    Ok(())
+}
+
+fn ensure_app_unix_identity(app_id: &str) -> Result<AppUnixIdentity, String> {
+    let user_name = app_unix_user_name(app_id);
+    let shared_gid = ensure_shared_app_group()?;
+    if let Some((uid, gid)) = crate::unix::lookup_user_ids(&user_name)
+        .map_err(|e| format!("Failed to resolve {user_name}: {e}"))?
+    {
+        return Ok(AppUnixIdentity {
+            user_name,
+            ids: UserIds {
+                uid,
+                gid,
+                supplementary_gids: vec![shared_gid],
+            },
+        });
+    }
+
+    create_app_user(&user_name, shared_gid)?;
+    let (uid, gid) = crate::unix::lookup_user_ids(&user_name)
+        .map_err(|e| format!("Failed to resolve created user {user_name}: {e}"))?
+        .ok_or_else(|| format!("Created user {user_name} was not found"))?;
+    Ok(AppUnixIdentity {
+        user_name,
+        ids: UserIds {
+            uid,
+            gid,
+            supplementary_gids: vec![shared_gid],
+        },
+    })
+}
+
+fn ensure_shared_app_group() -> Result<u32, String> {
+    if let Some(gid) = crate::unix::lookup_group_id(SHARED_APP_GROUP)
+        .map_err(|e| format!("Failed to resolve {SHARED_APP_GROUP} group: {e}"))?
+    {
+        return Ok(gid);
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let status = std::process::Command::new("groupadd")
+            .args(["--system", SHARED_APP_GROUP])
+            .status()
+            .map_err(|e| format!("create shared app group {SHARED_APP_GROUP}: {e}"))?;
+        if !status.success() {
+            return Err(format!(
+                "create shared app group {SHARED_APP_GROUP}: {status}"
+            ));
+        }
+        return crate::unix::lookup_group_id(SHARED_APP_GROUP)
+            .map_err(|e| format!("Failed to resolve created group {SHARED_APP_GROUP}: {e}"))?
+            .ok_or_else(|| format!("Created group {SHARED_APP_GROUP} was not found"));
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Err(format!(
+            "shared app group {SHARED_APP_GROUP} must exist before root can spawn app processes"
+        ))
+    }
+}
+
+fn create_app_user(user_name: &str, _shared_gid: u32) -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    {
+        let status = std::process::Command::new("useradd")
+            .args([
+                "--system",
+                "--user-group",
+                "--no-create-home",
+                "--home-dir",
+                "/nonexistent",
+                "--shell",
+                "/usr/sbin/nologin",
+                "--groups",
+                SHARED_APP_GROUP,
+                user_name,
+            ])
+            .status()
+            .map_err(|e| format!("create app user {user_name}: {e}"))?;
+        if !status.success() {
+            return Err(format!("create app user {user_name}: {status}"));
+        }
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Err(format!(
+            "per-app Unix users require Linux root; user {user_name} does not exist"
+        ))
+    }
+}
+
+fn prepare_app_cgroup(_data_dir: &Path, app_id: &str) -> Result<CgroupAssignment, String> {
+    #[cfg(target_os = "linux")]
+    {
+        let cgroup_root = current_cgroup_root()?.join("tako");
+        let app_cgroup = cgroup_root.join(app_unix_user_name(app_id));
+        std::fs::create_dir_all(&app_cgroup)
+            .map_err(|e| format!("create app cgroup {}: {e}", app_cgroup.display()))?;
+        write_if_exists(
+            app_cgroup.join("memory.max"),
+            CGROUP_MEMORY_MAX_BYTES.to_string(),
+        )?;
+        write_if_exists(app_cgroup.join("cpu.max"), CGROUP_CPU_MAX.to_string())?;
+        write_if_exists(app_cgroup.join("pids.max"), CGROUP_PIDS_MAX.to_string())?;
+        Ok(CgroupAssignment { path: app_cgroup })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = app_id;
+        Err("cgroups require Linux".to_string())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn current_cgroup_root() -> Result<PathBuf, String> {
+    let raw = std::fs::read_to_string("/proc/self/cgroup")
+        .map_err(|e| format!("read /proc/self/cgroup: {e}"))?;
+    let rel = raw
+        .lines()
+        .find_map(|line| line.strip_prefix("0::"))
+        .ok_or_else(|| "cgroup v2 is not available".to_string())?
+        .trim_start_matches('/');
+    Ok(Path::new("/sys/fs/cgroup").join(rel))
+}
+
+#[cfg(target_os = "linux")]
+fn write_if_exists(path: PathBuf, value: String) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+    std::fs::write(&path, value).map_err(|e| format!("write cgroup file {}: {e}", path.display()))
+}
+
+fn chown_path_tree(path: &Path, uid: u32, gid: u32) -> std::io::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    crate::unix::lchown_path(path, uid, gid)?;
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        for entry in std::fs::read_dir(path)? {
+            chown_path_tree(&entry?.path(), uid, gid)?;
+        }
+    }
+    Ok(())
+}
+
+fn app_child_parent_death_signal() -> Option<i32> {
+    #[cfg(target_os = "linux")]
+    {
+        Some(libc::SIGTERM)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::release::{app_runtime_data_paths, ensure_app_runtime_data_dirs};
+    use std::os::unix::fs::PermissionsExt;
+
+    fn mode(path: &Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o7777
+    }
+
+    #[test]
+    fn app_unix_user_name_is_stable_and_posix_friendly() {
+        let first = app_unix_user_name("notes/production");
+        let second = app_unix_user_name("notes/production");
+        assert_eq!(first, second);
+        assert!(first.starts_with(APP_USER_PREFIX));
+        assert!(first.len() <= 32);
+        assert!(
+            first
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        );
+    }
+
+    #[test]
+    fn app_unix_user_name_separates_environments() {
+        assert_ne!(
+            app_unix_user_name("notes/production"),
+            app_unix_user_name("notes/staging")
+        );
+    }
+
+    #[test]
+    fn prepare_app_filesystem_isolation_sets_private_modes_without_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let app_id = "notes/production";
+        let data_paths = ensure_app_runtime_data_dirs(temp.path(), app_id).unwrap();
+        let release_path = temp
+            .path()
+            .join("apps")
+            .join("notes")
+            .join("production")
+            .join("releases")
+            .join("v1");
+        std::fs::create_dir_all(&release_path).unwrap();
+
+        prepare_app_filesystem_isolation(temp.path(), app_id, Some(&release_path), &data_paths)
+            .unwrap();
+
+        let paths = app_runtime_data_paths(temp.path(), app_id);
+        assert_eq!(mode(&release_path), 0o750);
+        assert_eq!(mode(&paths.root), 0o710);
+        assert_eq!(mode(&paths.app), 0o2770);
+        assert_eq!(mode(&paths.tako), 0o700);
+    }
+}

--- a/tako-server/src/main.rs
+++ b/tako-server/src/main.rs
@@ -13,6 +13,7 @@ mod defaults;
 mod identity;
 mod image_worker;
 mod instances;
+mod isolation;
 mod lb;
 mod management_auth;
 mod management_http;

--- a/tako-server/src/operations/deploy.rs
+++ b/tako-server/src/operations/deploy.rs
@@ -96,6 +96,14 @@ impl crate::ServerState {
                 return Response::error(format!("Failed to create app data dirs: {error}"));
             }
         };
+        if let Err(error) = crate::isolation::prepare_app_filesystem_isolation(
+            &self.runtime.data_dir,
+            app_name,
+            Some(&release_path),
+            &data_paths,
+        ) {
+            return Response::error(format!("Failed to prepare app isolation: {error}"));
+        }
 
         let secrets = if let Some(new_secrets) = secrets {
             new_secrets

--- a/tako-server/src/operations/releases.rs
+++ b/tako-server/src/operations/releases.rs
@@ -71,9 +71,33 @@ impl crate::ServerState {
             Ok(paths) => paths,
             Err(error) => return Response::error(format!("Release preparation failed: {error}")),
         };
+        if let Err(error) = crate::isolation::prepare_app_filesystem_isolation(
+            &self.runtime.data_dir,
+            app_name,
+            Some(&release_path),
+            &data_paths,
+        ) {
+            return Response::error(format!("Release preparation failed: {error}"));
+        }
         inject_app_data_dir_env(&mut release_env, &data_paths);
 
-        match prepare_release_runtime(&release_path, &release_env, &self.runtime.data_dir).await {
+        let isolation =
+            match crate::isolation::app_process_isolation(&self.runtime.data_dir, app_name) {
+                Ok(isolation) => isolation,
+                Err(error) => {
+                    return Response::error(format!("Release preparation failed: {error}"));
+                }
+            };
+
+        match prepare_release_runtime(
+            &release_path,
+            &release_env,
+            &self.runtime.data_dir,
+            #[cfg(unix)]
+            Some(isolation),
+        )
+        .await
+        {
             Ok(_) => Response::ok(serde_json::json!({ "status": "prepared" })),
             Err(error) => Response::error(format!("Release preparation failed: {error}")),
         }
@@ -124,6 +148,14 @@ impl crate::ServerState {
                 return Response::error(format!("Failed to create app data dirs: {error}"));
             }
         };
+        if let Err(error) = crate::isolation::prepare_app_filesystem_isolation(
+            &self.runtime.data_dir,
+            app_name,
+            Some(&release_path),
+            &data_paths,
+        ) {
+            return Response::error(format!("Failed to prepare app isolation: {error}"));
+        }
 
         let mut env = env_vars;
         env.extend(vars);
@@ -134,7 +166,21 @@ impl crate::ServerState {
             env.entry("PATH".to_string()).or_insert(path);
         }
 
-        match release_command::run(command_line, &release_path, &env).await {
+        let isolation =
+            match crate::isolation::app_process_isolation(&self.runtime.data_dir, app_name) {
+                Ok(isolation) => isolation,
+                Err(error) => return Response::error(format!("Release command failed: {error}")),
+            };
+
+        match release_command::run(
+            command_line,
+            &release_path,
+            &env,
+            #[cfg(unix)]
+            Some(isolation),
+        )
+        .await
+        {
             Err(spawn_err) => Response::error(format!("Release command failed: {spawn_err}")),
             Ok(outcome) if outcome.succeeded() => Response::ok(serde_json::json!({
                 "status": "released",

--- a/tako-server/src/release.rs
+++ b/tako-server/src/release.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 use std::time::Duration;
+#[cfg(unix)]
+use tako_spawn::ProcessIsolation;
 use tokio::process::Command as TokioCommand;
 
 pub(crate) const TAKO_APP_DATA_DIR_ENV: &str = "TAKO_DATA_DIR";
@@ -219,36 +221,12 @@ fn derive_build_state(instances: &[InstanceStatus]) -> AppState {
 }
 
 #[cfg(unix)]
-fn resolve_app_user_for_install() -> std::io::Result<Option<(u32, u32)>> {
-    crate::unix::lookup_user_ids("tako-app")
-}
-
-#[cfg(unix)]
-fn drop_privileges_if_root(cmd: &mut TokioCommand) -> Result<(), String> {
-    if let Some((uid, gid)) =
-        app_user_for_install(resolve_app_user_for_install(), crate::unix::is_root())?
-    {
-        cmd.uid(uid);
-        cmd.gid(gid);
-    }
-
-    Ok(())
-}
-
-#[cfg(unix)]
-fn app_user_for_install(
-    lookup: std::io::Result<Option<(u32, u32)>>,
-    is_root: bool,
-) -> Result<Option<(u32, u32)>, String> {
-    if !is_root {
-        return Ok(None);
-    }
-
-    match lookup.map_err(|e| format!("Failed to resolve tako-app user: {e}"))? {
-        Some(user) => Ok(Some(user)),
-        None => {
-            Err("tako-app user not found; refusing to run production install as root".to_string())
-        }
+fn install_release_process_isolation(cmd: &mut TokioCommand, isolation: Option<ProcessIsolation>) {
+    let Some(isolation) = isolation else {
+        return;
+    };
+    unsafe {
+        cmd.pre_exec(move || tako_spawn::install_process_isolation(&isolation));
     }
 }
 
@@ -256,6 +234,7 @@ pub(crate) async fn prepare_release_runtime(
     release_dir: &Path,
     env: &HashMap<String, String>,
     data_dir: &Path,
+    #[cfg(unix)] isolation: Option<ProcessIsolation>,
 ) -> Result<Option<String>, String> {
     let manifest = load_release_manifest(release_dir)?;
     let runtime = &manifest.runtime;
@@ -319,9 +298,14 @@ pub(crate) async fn prepare_release_runtime(
         && let Some(install_cmd) = &def.package_manager.install
     {
         tracing::info!(runtime = %runtime, install_dir = %install_dir.display(), "Running production install: {}", install_cmd);
-        let output =
-            run_production_install_command(install_cmd.as_str(), &install_dir, &install_env)
-                .await?;
+        let output = run_production_install_command(
+            install_cmd.as_str(),
+            &install_dir,
+            &install_env,
+            #[cfg(unix)]
+            isolation.clone(),
+        )
+        .await?;
         if !output.status.success() {
             return Err(format_process_failure(
                 "production install",
@@ -339,6 +323,7 @@ async fn run_production_install_command(
     install_cmd: &str,
     install_dir: &Path,
     install_env: &HashMap<String, String>,
+    #[cfg(unix)] isolation: Option<ProcessIsolation>,
 ) -> Result<std::process::Output, String> {
     let mut cmd = TokioCommand::new("sh");
     cmd.args(["-c", install_cmd])
@@ -351,8 +336,26 @@ async fn run_production_install_command(
     }
     cmd.envs(install_env);
     #[cfg(unix)]
-    drop_privileges_if_root(&mut cmd)?;
-    cmd.output()
+    let cgroup = isolation.as_ref().and_then(|value| value.cgroup.clone());
+    #[cfg(unix)]
+    install_release_process_isolation(&mut cmd, isolation);
+    cmd.stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to run production install: {e}"))?;
+    #[cfg(unix)]
+    if let Some(cgroup) = cgroup
+        && let Some(pid) = child.id()
+        && let Err(error) = tako_spawn::assign_pid_to_cgroup(&cgroup, pid)
+    {
+        let _ = child.start_kill();
+        return Err(format!(
+            "Failed to assign production install to cgroup: {error}"
+        ));
+    }
+    child
+        .wait_with_output()
         .await
         .map_err(|e| format!("Failed to run production install: {e}"))
 }
@@ -647,6 +650,7 @@ mod tests {
             "printf %s \"${TAKO_SERVER_PARENT_SECRET:-missing}\"",
             temp.path(),
             &env,
+            None,
         )
         .await
         .unwrap();
@@ -656,27 +660,30 @@ mod tests {
         assert_eq!(String::from_utf8_lossy(&output.stdout), "missing");
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(unix)]
-    fn app_user_for_install_fails_closed_for_root_lookup_error() {
-        let err =
-            app_user_for_install(Err(std::io::Error::other("lookup failed")), true).unwrap_err();
-        assert!(err.contains("lookup failed"));
-    }
+    async fn production_install_applies_process_isolation() {
+        let temp = TempDir::new().unwrap();
+        let mut env = HashMap::new();
+        if let Ok(path) = std::env::var("PATH") {
+            env.insert("PATH".to_string(), path);
+        }
+        let isolation = ProcessIsolation {
+            resource_limits: tako_spawn::ResourceLimits {
+                open_files: None,
+                processes: None,
+                address_space_bytes: None,
+            },
+            umask: Some(0o027),
+            ..Default::default()
+        };
 
-    #[test]
-    #[cfg(unix)]
-    fn app_user_for_install_fails_closed_for_root_missing_user() {
-        let err = app_user_for_install(Ok(None), true).unwrap_err();
-        assert!(err.contains("refusing to run production install as root"));
-    }
+        let output = run_production_install_command("umask", temp.path(), &env, Some(isolation))
+            .await
+            .unwrap();
 
-    #[test]
-    #[cfg(unix)]
-    fn app_user_for_install_ignores_lookup_error_when_not_root() {
-        let app_user =
-            app_user_for_install(Err(std::io::Error::other("lookup failed")), false).unwrap();
-        assert_eq!(app_user, None);
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "0027");
     }
 
     struct EnvGuard {

--- a/tako-server/src/release_command.rs
+++ b/tako-server/src/release_command.rs
@@ -9,6 +9,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
 
+#[cfg(unix)]
+use tako_spawn::ProcessIsolation;
 use tokio::io::AsyncReadExt;
 use tokio::process::Command as TokioCommand;
 use tokio::time::timeout;
@@ -35,8 +37,17 @@ pub async fn run(
     command_line: &str,
     cwd: &Path,
     env: &HashMap<String, String>,
+    #[cfg(unix)] isolation: Option<ProcessIsolation>,
 ) -> Result<ReleaseCommandOutcome, String> {
-    run_with_timeout(command_line, cwd, env, RELEASE_COMMAND_TIMEOUT).await
+    run_with_timeout(
+        command_line,
+        cwd,
+        env,
+        RELEASE_COMMAND_TIMEOUT,
+        #[cfg(unix)]
+        isolation,
+    )
+    .await
 }
 
 async fn run_with_timeout(
@@ -44,6 +55,7 @@ async fn run_with_timeout(
     cwd: &Path,
     env: &HashMap<String, String>,
     timeout_duration: Duration,
+    #[cfg(unix)] isolation: Option<ProcessIsolation>,
 ) -> Result<ReleaseCommandOutcome, String> {
     let mut cmd = TokioCommand::new("sh");
     cmd.args(["-c", command_line])
@@ -53,10 +65,28 @@ async fn run_with_timeout(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
+    #[cfg(unix)]
+    let cgroup = isolation.as_ref().and_then(|value| value.cgroup.clone());
+    #[cfg(unix)]
+    if let Some(isolation) = isolation {
+        unsafe {
+            cmd.pre_exec(move || tako_spawn::install_process_isolation(&isolation));
+        }
+    }
 
     let mut child = cmd
         .spawn()
         .map_err(|e| format!("Failed to spawn release command: {e}"))?;
+    #[cfg(unix)]
+    if let Some(cgroup) = cgroup
+        && let Some(pid) = child.id()
+        && let Err(error) = tako_spawn::assign_pid_to_cgroup(&cgroup, pid)
+    {
+        let _ = child.start_kill();
+        return Err(format!(
+            "Failed to assign release command to cgroup: {error}"
+        ));
+    }
 
     let mut stdout_pipe = child.stdout.take().expect("piped stdout");
     let mut stderr_pipe = child.stderr.take().expect("piped stderr");
@@ -106,7 +136,9 @@ mod tests {
     #[tokio::test]
     async fn runs_successful_command() {
         let dir = TempDir::new().unwrap();
-        let outcome = run("echo hello", dir.path(), &empty_env()).await.unwrap();
+        let outcome = run("echo hello", dir.path(), &empty_env(), None)
+            .await
+            .unwrap();
         assert!(outcome.succeeded());
         assert_eq!(outcome.exit_code, Some(0));
         assert!(outcome.stdout.contains("hello"));
@@ -116,7 +148,7 @@ mod tests {
     #[tokio::test]
     async fn captures_nonzero_exit() {
         let dir = TempDir::new().unwrap();
-        let outcome = run("exit 7", dir.path(), &empty_env()).await.unwrap();
+        let outcome = run("exit 7", dir.path(), &empty_env(), None).await.unwrap();
         assert!(!outcome.succeeded());
         assert_eq!(outcome.exit_code, Some(7));
     }
@@ -126,7 +158,9 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let mut env = empty_env();
         env.insert("FOO".to_string(), "bar-value".to_string());
-        let outcome = run("printf %s \"$FOO\"", dir.path(), &env).await.unwrap();
+        let outcome = run("printf %s \"$FOO\"", dir.path(), &env, None)
+            .await
+            .unwrap();
         assert!(outcome.succeeded());
         assert_eq!(outcome.stdout, "bar-value");
     }
@@ -136,7 +170,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let marker = dir.path().join("marker.txt");
         std::fs::write(&marker, "hi").unwrap();
-        let outcome = run("ls marker.txt", dir.path(), &empty_env())
+        let outcome = run("ls marker.txt", dir.path(), &empty_env(), None)
             .await
             .unwrap();
         assert!(outcome.succeeded());
@@ -146,7 +180,7 @@ mod tests {
     #[tokio::test]
     async fn captures_stderr() {
         let dir = TempDir::new().unwrap();
-        let outcome = run("echo oops 1>&2; exit 1", dir.path(), &empty_env())
+        let outcome = run("echo oops 1>&2; exit 1", dir.path(), &empty_env(), None)
             .await
             .unwrap();
         assert_eq!(outcome.exit_code, Some(1));
@@ -163,6 +197,7 @@ mod tests {
             dir.path(),
             &empty_env(),
             Duration::from_millis(25),
+            None,
         )
         .await
         .unwrap();
@@ -180,9 +215,30 @@ mod tests {
             "printf %s \"${RELEASE_TEST_LEAK:-EMPTY}\"",
             dir.path(),
             &empty_env(),
+            None,
         )
         .await
         .unwrap();
         assert_eq!(outcome.stdout, "EMPTY");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn applies_release_command_umask() {
+        let dir = TempDir::new().unwrap();
+        let isolation = ProcessIsolation {
+            resource_limits: tako_spawn::ResourceLimits {
+                open_files: None,
+                processes: None,
+                address_space_bytes: None,
+            },
+            umask: Some(0o027),
+            ..Default::default()
+        };
+        let outcome = run("umask", dir.path(), &empty_env(), Some(isolation))
+            .await
+            .unwrap();
+        assert!(outcome.succeeded());
+        assert_eq!(outcome.stdout.trim(), "0027");
     }
 }

--- a/tako-server/src/server_state.rs
+++ b/tako-server/src/server_state.rs
@@ -464,6 +464,16 @@ impl ServerState {
 
         let secrets = self.state_store.get_secrets(app_name).unwrap_or_default();
         let storages = self.state_store.get_storages(app_name).unwrap_or_default();
+        let isolation = match crate::isolation::app_process_isolation(
+            &self.runtime.data_dir,
+            app_name,
+        ) {
+            Ok(isolation) => isolation,
+            Err(error) => {
+                tracing::warn!(app = app_name, error = %error, "Skipping workflow engine: failed to prepare app isolation");
+                return;
+            }
+        };
 
         let app = app_name.to_string();
         let app_for_spec = app.clone();
@@ -484,6 +494,7 @@ impl ServerState {
                     worker_env,
                     secrets,
                     storages,
+                    Some(isolation),
                 )
             })
             .await;

--- a/tako-server/src/unix.rs
+++ b/tako-server/src/unix.rs
@@ -57,9 +57,58 @@ pub(crate) fn lookup_user_ids(name: &str) -> io::Result<Option<(u32, u32)>> {
     }
 }
 
+pub(crate) fn lookup_group_id(name: &str) -> io::Result<Option<u32>> {
+    let name = CString::new(name).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "group name contains interior NUL byte",
+        )
+    })?;
+    let mut entry = std::mem::MaybeUninit::<libc::group>::uninit();
+    let mut result = std::ptr::null_mut();
+    let mut buf = vec![0u8; group_buffer_size()];
+
+    loop {
+        // SAFETY: name is a valid NUL-terminated C string. entry points to
+        // writable group storage, buf is a writable byte buffer, and result
+        // points to writable pointer storage.
+        let rc = unsafe {
+            libc::getgrnam_r(
+                name.as_ptr(),
+                entry.as_mut_ptr(),
+                buf.as_mut_ptr().cast(),
+                buf.len(),
+                &mut result,
+            )
+        };
+
+        if rc == 0 {
+            if result.is_null() {
+                return Ok(None);
+            }
+            // SAFETY: getgrnam_r returned success and result points at entry.
+            let entry = unsafe { entry.assume_init() };
+            return Ok(Some(entry.gr_gid));
+        }
+
+        if rc == libc::ERANGE {
+            buf.resize(buf.len() * 2, 0);
+            continue;
+        }
+
+        return Err(io::Error::from_raw_os_error(rc));
+    }
+}
+
 fn passwd_buffer_size() -> usize {
     // SAFETY: sysconf has no preconditions for _SC_GETPW_R_SIZE_MAX.
     let size = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
+    if size > 0 { size as usize } else { 16 * 1024 }
+}
+
+fn group_buffer_size() -> usize {
+    // SAFETY: sysconf has no preconditions for _SC_GETGR_R_SIZE_MAX.
+    let size = unsafe { libc::sysconf(libc::_SC_GETGR_R_SIZE_MAX) };
     if size > 0 { size as usize } else { 16 * 1024 }
 }
 
@@ -73,6 +122,22 @@ pub(crate) fn chown_path(path: &Path, uid: u32, gid: u32) -> io::Result<()> {
     // SAFETY: path is a valid NUL-terminated C string. uid and gid are plain
     // integer identifiers from the OS user database.
     let rc = unsafe { libc::chown(path.as_ptr(), uid as libc::uid_t, gid as libc::gid_t) };
+    if rc == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+pub(crate) fn lchown_path(path: &Path, uid: u32, gid: u32) -> io::Result<()> {
+    let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "path contains interior NUL byte",
+        )
+    })?;
+    // SAFETY: path is a valid NUL-terminated C string. uid and gid are plain
+    // integer identifiers from the OS user database.
+    let rc = unsafe { libc::lchown(path.as_ptr(), uid as libc::uid_t, gid as libc::gid_t) };
     if rc == -1 {
         return Err(io::Error::last_os_error());
     }
@@ -97,6 +162,15 @@ mod tests {
         assert_eq!(
             lookup_user_ids("bad\0name").unwrap_err().kind(),
             io::ErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn lookup_group_id_returns_none_for_missing_group() {
+        assert!(
+            lookup_group_id("this-group-definitely-does-not-exist-tako-test")
+                .unwrap()
+                .is_none()
         );
     }
 }

--- a/tako-spawn/src/lib.rs
+++ b/tako-spawn/src/lib.rs
@@ -8,7 +8,195 @@
 #![cfg(unix)]
 
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::path::PathBuf;
 use std::thread::JoinHandle;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserIds {
+    pub uid: u32,
+    pub gid: u32,
+    pub supplementary_gids: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResourceLimits {
+    pub open_files: Option<u64>,
+    pub processes: Option<u64>,
+    pub address_space_bytes: Option<u64>,
+}
+
+impl Default for ResourceLimits {
+    fn default() -> Self {
+        Self {
+            open_files: Some(4096),
+            processes: Some(512),
+            address_space_bytes: Some(2 * 1024 * 1024 * 1024),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CgroupAssignment {
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessIsolation {
+    pub user: Option<UserIds>,
+    pub cgroup: Option<CgroupAssignment>,
+    pub resource_limits: ResourceLimits,
+    pub parent_death_signal: Option<i32>,
+    pub no_new_privs: bool,
+    pub clear_ambient_capabilities: bool,
+    pub umask: Option<u32>,
+}
+
+impl Default for ProcessIsolation {
+    fn default() -> Self {
+        Self {
+            user: None,
+            cgroup: None,
+            resource_limits: ResourceLimits::default(),
+            parent_death_signal: None,
+            no_new_privs: true,
+            clear_ambient_capabilities: true,
+            umask: Some(0o027),
+        }
+    }
+}
+
+pub fn assign_pid_to_cgroup(cgroup: &CgroupAssignment, pid: u32) -> std::io::Result<()> {
+    std::fs::write(cgroup.path.join("cgroup.procs"), pid.to_string())
+}
+
+/// Apply child-side process hardening from a `pre_exec` hook.
+///
+/// # Safety
+///
+/// Must be called only in the child process after `fork` and before `exec`.
+/// The implementation only uses libc calls with plain integer arguments.
+pub unsafe fn install_process_isolation(isolation: &ProcessIsolation) -> std::io::Result<()> {
+    install_parent_death_signal(isolation.parent_death_signal)?;
+    if isolation.clear_ambient_capabilities {
+        clear_ambient_capabilities()?;
+    }
+    apply_resource_limits(isolation.resource_limits)?;
+    if let Some(mask) = isolation.umask {
+        unsafe { libc::umask(mask as libc::mode_t) };
+    }
+    if isolation.no_new_privs {
+        set_no_new_privs()?;
+    }
+    if let Some(user) = &isolation.user {
+        drop_to_user(user)?;
+    }
+    Ok(())
+}
+
+fn apply_resource_limits(limits: ResourceLimits) -> std::io::Result<()> {
+    if let Some(value) = limits.open_files {
+        set_resource_limit(libc::RLIMIT_NOFILE as _, value)?;
+    }
+    if let Some(value) = limits.processes {
+        set_resource_limit(libc::RLIMIT_NPROC as _, value)?;
+    }
+    if let Some(value) = limits.address_space_bytes {
+        set_resource_limit(libc::RLIMIT_AS as _, value)?;
+    }
+    Ok(())
+}
+
+fn set_resource_limit(resource: u32, value: u64) -> std::io::Result<()> {
+    let limit = libc::rlimit {
+        rlim_cur: value as libc::rlim_t,
+        rlim_max: value as libc::rlim_t,
+    };
+    // SAFETY: `limit` points to initialized rlimit storage and `resource` is a
+    // libc RLIMIT_* constant.
+    if unsafe { libc::setrlimit(resource as _, &limit) } == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn set_no_new_privs() -> std::io::Result<()> {
+    // SAFETY: prctl is called with PR_SET_NO_NEW_PRIVS and integer arguments.
+    if unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn set_no_new_privs() -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn clear_ambient_capabilities() -> std::io::Result<()> {
+    // SAFETY: prctl is called with PR_CAP_AMBIENT_CLEAR_ALL and integer args.
+    if unsafe {
+        libc::prctl(
+            libc::PR_CAP_AMBIENT,
+            libc::PR_CAP_AMBIENT_CLEAR_ALL,
+            0,
+            0,
+            0,
+        )
+    } == -1
+    {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn clear_ambient_capabilities() -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn install_parent_death_signal(signal: Option<i32>) -> std::io::Result<()> {
+    let Some(signal) = signal else {
+        return Ok(());
+    };
+
+    // SAFETY: prctl, getppid, and _exit are used with plain integer arguments
+    // in the child after fork and before exec.
+    if unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, signal) } == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::getppid() } == 1 {
+        unsafe { libc::_exit(1) };
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn install_parent_death_signal(_signal: Option<i32>) -> std::io::Result<()> {
+    Ok(())
+}
+
+fn drop_to_user(user: &UserIds) -> std::io::Result<()> {
+    let groups: Vec<libc::gid_t> = user
+        .supplementary_gids
+        .iter()
+        .copied()
+        .map(|gid| gid as libc::gid_t)
+        .collect();
+    // SAFETY: setgroups, setgid, and setuid are called with OS-provided ids.
+    if unsafe { libc::setgroups(groups.len() as _, groups.as_ptr()) } == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::setgid(user.gid as libc::gid_t) } == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::setuid(user.uid as libc::uid_t) } == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
 
 /// Set `FD_CLOEXEC` on `fd` so it does not survive `exec` in a forked
 /// child.
@@ -72,6 +260,8 @@ pub fn create_payload_pipe(
 mod tests {
     use super::*;
     use std::io::Read;
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command, Stdio};
     use std::sync::mpsc;
     use std::time::{Duration, Instant};
 
@@ -129,10 +319,6 @@ mod tests {
     /// safe path and wouldn't exercise CLOEXEC.
     #[test]
     fn payload_pipe_child_sees_eof_when_write_end_leaks_past_fork() {
-        use std::os::unix::process::CommandExt;
-        use std::process::{Command, Stdio};
-        use std::time::{Duration, Instant};
-
         let big = vec![b'x'; 256 * 1024];
         let (read_end, writer) = create_payload_pipe(big).expect("create pipe");
         let raw_read_fd = read_end.as_raw_fd();
@@ -203,5 +389,67 @@ mod tests {
 
         assert_eq!(buf.len(), big.len());
         assert_eq!(buf, big);
+    }
+
+    #[test]
+    fn process_isolation_sets_child_umask() {
+        let isolation = ProcessIsolation {
+            resource_limits: ResourceLimits {
+                open_files: None,
+                processes: None,
+                address_space_bytes: None,
+            },
+            umask: Some(0o027),
+            ..Default::default()
+        };
+
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "umask"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        unsafe {
+            cmd.pre_exec(move || install_process_isolation(&isolation));
+        }
+
+        let output = cmd.output().expect("spawn child");
+        assert!(
+            output.status.success(),
+            "child failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "0027");
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn process_isolation_sets_no_new_privs() {
+        let isolation = ProcessIsolation {
+            resource_limits: ResourceLimits {
+                open_files: None,
+                processes: None,
+                address_space_bytes: None,
+            },
+            no_new_privs: true,
+            umask: None,
+            ..Default::default()
+        };
+
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "awk '/^NoNewPrivs:/ { print $2 }' /proc/self/status"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        unsafe {
+            cmd.pre_exec(move || install_process_isolation(&isolation));
+        }
+
+        let output = cmd.output().expect("spawn child");
+        assert!(
+            output.status.success(),
+            "child failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "1");
     }
 }

--- a/tako-workflows/src/manager.rs
+++ b/tako-workflows/src/manager.rs
@@ -282,6 +282,7 @@ pub fn worker_spec_for_bun(
     mut env: std::collections::HashMap<String, String>,
     secrets: std::collections::HashMap<String, String>,
     storages: std::collections::HashMap<String, tako_core::StorageBinding>,
+    isolation: Option<tako_spawn::ProcessIsolation>,
 ) -> WorkerSpec {
     env.insert(
         tako_core::instance_env::TAKO_APP_NAME_ENV.into(),
@@ -305,6 +306,7 @@ pub fn worker_spec_for_bun(
         secrets,
         storages,
         log_sink: None,
+        isolation,
     }
 }
 
@@ -326,6 +328,7 @@ mod tests {
             secrets: StdHashMap::new(),
             storages: StdHashMap::new(),
             log_sink: None,
+            isolation: None,
         }
     }
 

--- a/tako-workflows/src/supervisor.rs
+++ b/tako-workflows/src/supervisor.rs
@@ -64,6 +64,8 @@ pub struct WorkerSpec {
     /// parent's stdio (production default — lets journald/systemd capture
     /// it).
     pub log_sink: Option<WorkerLogSink>,
+    /// Optional production process isolation for server-managed workers.
+    pub isolation: Option<tako_spawn::ProcessIsolation>,
 }
 
 impl WorkerSpec {
@@ -399,6 +401,10 @@ impl WorkerSupervisor {
                 .map_err(SupervisorError::Spawn)?;
         #[cfg(unix)]
         let bootstrap_fd: RawFd = bootstrap_read_end.as_raw_fd();
+        #[cfg(unix)]
+        let isolation = self.spec.isolation.clone();
+        #[cfg(unix)]
+        let cgroup = isolation.as_ref().and_then(|value| value.cgroup.clone());
 
         #[cfg(unix)]
         unsafe {
@@ -408,6 +414,9 @@ impl WorkerSupervisor {
                         return Err(std::io::Error::last_os_error());
                     }
                     libc::close(bootstrap_fd);
+                }
+                if let Some(isolation) = &isolation {
+                    tako_spawn::install_process_isolation(isolation)?;
                 }
                 Ok(())
             });
@@ -442,6 +451,15 @@ impl WorkerSupervisor {
         };
         #[cfg(not(unix))]
         let mut child = spawn_result?;
+
+        #[cfg(unix)]
+        if let Some(cgroup) = cgroup
+            && let Some(pid) = child.id()
+            && let Err(error) = tako_spawn::assign_pid_to_cgroup(&cgroup, pid)
+        {
+            let _ = child.start_kill();
+            return Err(SupervisorError::Spawn(error));
+        }
 
         if let Some(sink) = &self.spec.log_sink {
             if let Some(stdout) = child.stdout.take() {

--- a/tako-workflows/src/supervisor/tests.rs
+++ b/tako-workflows/src/supervisor/tests.rs
@@ -14,6 +14,7 @@ fn sleep_spec(cwd: PathBuf, workers: u32, sleep_secs: &str) -> WorkerSpec {
         secrets: HashMap::new(),
         storages: HashMap::new(),
         log_sink: None,
+        isolation: None,
     }
 }
 
@@ -81,6 +82,7 @@ async fn shutdown_reaps_children_that_ignore_sigterm() {
         secrets: HashMap::new(),
         storages: HashMap::new(),
         log_sink: None,
+        isolation: None,
     };
     let sup = WorkerSupervisor::new(spec);
     sup.start().await.unwrap();
@@ -118,6 +120,7 @@ fn failing_spec(cwd: PathBuf) -> WorkerSpec {
         secrets: HashMap::new(),
         storages: HashMap::new(),
         log_sink: None,
+        isolation: None,
     }
 }
 
@@ -181,6 +184,7 @@ async fn clean_idle_exit_does_not_mark_unhealthy() {
         secrets: HashMap::new(),
         storages: HashMap::new(),
         log_sink: None,
+        isolation: None,
     };
     let sup = WorkerSupervisor::new(spec);
     sup.wake().unwrap();
@@ -202,6 +206,7 @@ async fn background_reaper_collects_clean_idle_exit_without_poll() {
         secrets: HashMap::new(),
         storages: HashMap::new(),
         log_sink: None,
+        isolation: None,
     };
     let sup = WorkerSupervisor::new(spec);
     sup.wake().unwrap();
@@ -301,6 +306,7 @@ async fn effective_env_sets_concurrency_and_idle_timeout() {
         secrets: HashMap::new(),
         storages: HashMap::new(),
         log_sink: None,
+        isolation: None,
     };
     let env = spec.effective_env();
     assert_eq!(

--- a/tako/src/bin/tako-dev-server/control/handlers/apps.rs
+++ b/tako/src/bin/tako-dev-server/control/handlers/apps.rs
@@ -212,6 +212,7 @@ pub(super) async fn register_app(
             secrets: worker_secrets,
             storages: worker_storages,
             log_sink,
+            isolation: None,
         };
         if let Err(e) = workflows.ensure(&app_name, spec_fn).await {
             tracing::warn!(

--- a/website/src/pages/docs/deployment.md
+++ b/website/src/pages/docs/deployment.md
@@ -18,7 +18,7 @@ Install `tako-server` on a Linux host:
 sudo sh -c "$(curl -fsSL https://tako.sh/install-server.sh)"
 ```
 
-The installer creates the `tako` service user, the `tako-app` runtime user, `/opt/tako`, `/var/run/tako`, service units with high file-descriptor limits, maintenance helpers, restricted sudoers policy, public HTTP/HTTPS listeners, local metrics, libvips runtime support, and private Tailscale management.
+The installer creates the `tako` service user, the shared `tako-app` socket-access group, `/opt/tako`, `/var/run/tako`, service units with high file-descriptor limits, maintenance helpers, restricted sudoers policy, public HTTP/HTTPS listeners, local metrics, libvips runtime support, and private Tailscale management.
 
 Custom public proxy ports:
 
@@ -107,7 +107,7 @@ Uploads go through private signed management:
 POST /release-artifact
 ```
 
-The server verifies declared size and SHA-256, extracts into `/opt/tako/apps/{app}/{env}/releases/{version}/`, links release logs to the app log directory, runs the runtime plugin's production install command, and prepares runtime metadata.
+The server verifies declared size and SHA-256, extracts into `/opt/tako/apps/{app}/{env}/releases/{version}/`, links release logs to the app log directory, prepares the per-app Unix identity and filesystem permissions, runs the runtime plugin's production install command as that app identity, and prepares runtime metadata.
 
 Small management commands use `POST /rpc`. Logs use `POST /logs`. App/runtime management uses signed HTTP over Tailscale; SSH is for setup, recovery, reload, upgrade, and uninstall.
 
@@ -119,7 +119,7 @@ Set a one-shot release command for migrations or cache preparation:
 release = "bun run db:migrate"
 ```
 
-The command runs once on the leader server, inside the new release directory, before rolling update. Followers wait for the leader result. If it fails, deploy aborts on every server, removes partial release directories, leaves `current` unchanged, and old instances keep serving.
+The command runs once on the leader server, inside the new release directory as the app's per-app Unix identity, before rolling update. Followers wait for the leader result. If it fails, deploy aborts on every server, removes partial release directories, leaves `current` unchanged, and old instances keep serving.
 
 Disable an inherited command for one environment:
 

--- a/website/src/pages/docs/how-tako-works.md
+++ b/website/src/pages/docs/how-tako-works.md
@@ -48,7 +48,7 @@ A deploy builds locally and ships a prepared artifact to each server:
 5. Run build stages in order, merge configured assets into `public/`, and write `app.json`.
 6. Package a target-specific artifact and reuse the local artifact cache when inputs match.
 7. Upload over signed private HTTP management.
-8. Prepare the release on each server and run production install there.
+8. Prepare the release on each server, apply per-app Unix identity/permissions, and run production install there.
 9. Run the optional `release` command once on the leader server.
 10. Roll new instances into traffic, finalize `current`, prune old releases, and create a post-deploy backup when enabled.
 

--- a/website/src/pages/docs/tako-toml.md
+++ b/website/src/pages/docs/tako-toml.md
@@ -346,7 +346,7 @@ Per-environment `release` overrides it. An empty string disables the inherited c
 release = ""
 ```
 
-Release commands run as `sh -c "<command>"` inside the new release directory with non-secret vars and decrypted secrets. If the command fails, deploy aborts on every server, removes partial release directories, leaves `current` untouched, and old instances keep serving.
+Release commands run as `sh -c "<command>"` inside the new release directory as the app's per-app Unix identity, with non-secret vars and decrypted secrets. If the command fails, deploy aborts on every server, removes partial release directories, leaves `current` untouched, and old instances keep serving.
 
 ## Images
 

--- a/website/src/pages/docs/troubleshooting.md
+++ b/website/src/pages/docs/troubleshooting.md
@@ -193,7 +193,7 @@ Without a pin, deploy runs the local runtime's `--version` and falls back to `la
 
 ### Deploy fails during release command
 
-The `release` command runs once on the leader server before rolling update. If it exits non-zero, times out, or is signaled, deploy aborts everywhere, removes partial release directories, leaves `current` untouched, and old instances keep serving.
+The `release` command runs once on the leader server as the app's per-app Unix identity before rolling update. If it exits non-zero, times out, or is signaled, deploy aborts everywhere, removes partial release directories, leaves `current` untouched, and old instances keep serving.
 
 Disable an inherited release command for one environment:
 


### PR DESCRIPTION
## Summary

- add shared process hardening for production app subprocesses, including per-app users, resource limits, no-new-privs, umask hardening, parent-death signaling, and best-effort cgroup assignment
- apply the isolation profile to HTTP instances, release commands, runtime install commands, and workflow workers
- prepare app filesystem ownership/modes so per-app users can read releases and write only app-owned runtime data/logs while server-owned state stays protected
- update SPEC and derived website docs for the new production process isolation behavior

Closes #86.

## Validation

- `cargo fmt --all`
- `cargo test -p tako-spawn`
- `cargo test -p tako-workflows`
- `cargo test -p tako-server isolation::tests -- --test-threads=1`
- `cargo test -p tako-server release::tests -- --test-threads=1`
- `cargo test -p tako-server release_command::tests -- --test-threads=1`
- `cargo test -p tako-server instances::spawner::tests -- --test-threads=1`
- `cargo test -p tako-server --test server_integration -- --test-threads=1`
- pre-commit hook: `cargo fmt`, `bun run fmt`, `gofmt`, `cargo clippy --fix --workspace --all-targets`, `bun run lint`, `bun run --filter "*" typecheck`, `go vet`, `cargo test --workspace --lib --bins`, `cargo test -p tako --test cli_integration`, `bun run --filter website check`, `bun run --filter website build`, `lychee --offline --root-dir website/dist "website/dist/**/*.html"`
