### PR TITLE
fix(ci): keep bun.lock readable by Workers Builds

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,5 @@
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 1,
   "workspaces": {
     "": {


### PR DESCRIPTION
GitHub Actions is green. The red check on master is **Workers Builds: tako-website**.

## Cause

#127 (lock file maintenance) ran under Bun 1.4, which writes `lockfileVersion: 2`. Cloudflare Workers Builds still defaults to **Bun 1.2.15**, which cannot parse that lockfile:

```
error: Unknown lockfile version
    at bun.lock:2:22
```

Last green Workers Build: `9e7efd96`. First red: `3a721903`.

## Fix

Keep `bun.lock` at `lockfileVersion: 1`. Frozen installs succeed on Bun 1.2.15 and 1.4.0.

## Follow-up

Pin `BUN_VERSION=1.4.0` on the tako-website Workers Builds settings. Otherwise the next Bun 1.4 lockfile refresh will write version 2 again and the check will go red.

https://developers.cloudflare.com/workers/ci-cd/builds/build-image/